### PR TITLE
chore: align Go toolchain to go 1.25.0 with toolchain go1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/giantswarm/klaus-operator
 
 go 1.25.0
 
+toolchain go1.26.0
+
 require (
 	github.com/mark3labs/mcp-go v0.44.0
 	k8s.io/api v0.35.1


### PR DESCRIPTION
## Summary
- Add `toolchain go1.26.0` directive to `go.mod`
- Aligns with other Giant Swarm repos (mcp-kubernetes, muster, etc.)

## Test plan
- [x] `go build ./...` passes
- [x] `go mod tidy` produces no changes

Made with [Cursor](https://cursor.com)