### PR TITLE
fix: restructure CI for faster PR builds and add multiarch support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@6.13.0
+  architect: giantswarm/architect@6.14.0
 
 workflows:
   test:
@@ -11,21 +11,35 @@ workflows:
           name: go-build
           binary: klaus-operator
           filters:
-            # Trigger job also on git tag.
             tags:
               only: /^v.*/
-      - architect/push-to-registries:
+
+      # Branch builds: amd64 only for faster PR feedback
+      - architect/push-to-registries-multiarch:
           context: architect
           name: push-to-registries
+          platforms: "linux/amd64"
+          requires:
+            - go-build
+          filters:
+            branches:
+              ignore:
+                - main
+                - master
+
+      # Tag builds: full multi-arch (amd64 + arm64)
+      - architect/push-to-registries-multiarch:
+          context: architect
+          name: push-to-registries-release
           requires:
             - go-build
           filters:
             tags:
               only: /^v.*/
             branches:
-              ignore:
-                - main
-                - master
+              ignore: /.*/
+
+      # Branch: push chart after images
       - architect/push-to-app-catalog:
           context: architect
           name: push-to-app-catalog
@@ -35,9 +49,22 @@ workflows:
           requires:
             - push-to-registries
           filters:
-            tags:
-              only: /^v.*/
             branches:
               ignore:
                 - main
                 - master
+
+      # Tag: push chart after images
+      - architect/push-to-app-catalog:
+          context: architect
+          name: push-to-app-catalog-release
+          app_catalog: giantswarm-catalog
+          app_catalog_test: giantswarm-test-catalog
+          chart: klaus-operator
+          requires:
+            - push-to-registries-release
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
+FROM --platform=$BUILDPLATFORM golang:1.26.0 AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags "-w -extldflags '-static'" \
+    -o klaus-operator .
+
 FROM gsoci.azurecr.io/giantswarm/alpine:3.23.3
 
 RUN apk add --no-cache ca-certificates
 
-ADD ./klaus-operator /klaus-operator
+COPY --from=builder /app/klaus-operator /klaus-operator
 
 USER 65532:65532
 


### PR DESCRIPTION
## Summary

- **Switch to `push-to-registries-multiarch`**: Use `platforms: "linux/amd64"` on branches for faster PR feedback, avoiding cross-compilation and slow Aliyun registry push timeouts on dev images. Release tags build full multi-arch (amd64 + arm64).

- **Add multiarch Dockerfile**: Build the Go binary inside Docker using `FROM --platform=$BUILDPLATFORM` with buildx cross-compilation (`TARGETOS`/`TARGETARCH`), replacing the previous approach of ADDing a pre-built binary. This enables proper multi-architecture images on release tags.

- **Split branch/tag CI flows**: Separate image push and chart push jobs for branches vs tags, so each path has clean dependencies. Bump architect orb to 6.14.0.

## Test plan

- [ ] Verify branch CI build passes with amd64-only image push
- [ ] Verify the built image runs correctly
- [ ] Create a test tag to verify full multi-arch release flow

Made with [Cursor](https://cursor.com)