### PR TITLE
fix: create GitHub Release in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -55,3 +55,12 @@ jobs:
           git tag "$NEXT_VERSION"
           git push origin "$NEXT_VERSION"
           echo "Created and pushed tag $NEXT_VERSION"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+        run: |
+          gh release create "$NEXT_VERSION" \
+            --title "$NEXT_VERSION" \
+            --generate-notes


### PR DESCRIPTION
## Summary

- The auto-release workflow was only creating and pushing git tags without creating actual GitHub Releases, so the repository showed tags but no releases.
- Added a `gh release create` step with `--generate-notes` after the tag is pushed, so each auto-release now produces a proper GitHub Release with auto-generated release notes.
- Backfilled missing releases for `v0.0.1` and `v0.0.2` manually.

## Test plan

- [ ] Merge this PR and verify the auto-release workflow creates both a tag and a GitHub Release.

Made with [Cursor](https://cursor.com)