### PR TITLE
ci: fix pre-commit auto-formatter violations

### DIFF
--- a/internal/controller/klausinstance_controller.go
+++ b/internal/controller/klausinstance_controller.go
@@ -291,7 +291,7 @@ func (r *KlausInstanceReconciler) copyAPIKeySecret(ctx context.Context, instance
 
 	apiKey, ok := srcSecret.Data["api-key"]
 	if !ok {
-		return false, fmt.Errorf("Anthropic API key secret missing 'api-key' field")
+		return false, fmt.Errorf("anthropic API key secret missing 'api-key' field")
 	}
 
 	// Create or update the secret in the instance namespace.

--- a/internal/mcp/agent_test.go
+++ b/internal/mcp/agent_test.go
@@ -351,7 +351,7 @@ func TestHandleGetResult_Summary(t *testing.T) {
 	if data.Instance != "my-agent" {
 		t.Errorf("instance = %q, want %q", data.Instance, "my-agent")
 	}
-	if data.Status != "completed" {
+	if data.Status != "completed" { //nolint:goconst
 		t.Errorf("status = %q, want %q", data.Status, "completed")
 	}
 	if data.MessageCount != 5 {

--- a/internal/mcp/run.go
+++ b/internal/mcp/run.go
@@ -127,7 +127,7 @@ func (s *Server) handleRunInstance(ctx context.Context, request mcpgolang.CallTo
 		return mcpError(fmt.Sprintf("prompt sent but waiting for result failed: %v", err)), nil
 	}
 
-	res.Status = "completed"
+	res.Status = "completed" //nolint:goconst
 	res.Result = result
 	return mcpSuccess(res), nil
 }

--- a/internal/mcp/run_test.go
+++ b/internal/mcp/run_test.go
@@ -99,7 +99,7 @@ func TestHandleRunInstance_NonBlocking(t *testing.T) {
 	if data.SessionID != "sess-run-1" {
 		t.Errorf("session_id = %q, want %q", data.SessionID, "sess-run-1")
 	}
-	if data.Owner != "user@example.com" {
+	if data.Owner != "user@example.com" { //nolint:goconst
 		t.Errorf("owner = %q, want %q", data.Owner, "user@example.com")
 	}
 	if data.Model != "claude-sonnet-4-20250514" {

--- a/internal/mcp/spec_test.go
+++ b/internal/mcp/spec_test.go
@@ -99,7 +99,7 @@ func TestBuildInstanceSpec_Defaults(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if spec.Owner != "user@example.com" {
+	if spec.Owner != "user@example.com" { //nolint:goconst
 		t.Errorf("Owner = %q, want %q", spec.Owner, "user@example.com")
 	}
 	if spec.Claude.Model != "claude-sonnet-4-20250514" {
@@ -139,7 +139,7 @@ func TestBuildInstanceSpec_AllHighPriority(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if spec.Claude.Model != "claude-opus-4-20250514" {
+	if spec.Claude.Model != "claude-opus-4-20250514" { //nolint:goconst
 		t.Errorf("Model = %q, want %q", spec.Claude.Model, "claude-opus-4-20250514")
 	}
 	if spec.Claude.SystemPrompt != "You are a helpful assistant" {
@@ -148,7 +148,7 @@ func TestBuildInstanceSpec_AllHighPriority(t *testing.T) {
 	if spec.Personality != "gsoci.azurecr.io/giantswarm/personalities/go-dev:latest" {
 		t.Errorf("Personality = %q", spec.Personality)
 	}
-	if spec.Image != "gsoci.azurecr.io/giantswarm/klaus-go:1.25" {
+	if spec.Image != "gsoci.azurecr.io/giantswarm/klaus-go:1.25" { //nolint:goconst
 		t.Errorf("Image = %q", spec.Image)
 	}
 	if spec.Claude.PermissionMode != klausv1alpha1.PermissionModeDefault {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -309,7 +309,7 @@ func (s *Server) handleGetLogs(ctx context.Context, request mcpgolang.CallToolRe
 	if err != nil {
 		return mcpError(fmt.Sprintf("failed to get logs for container %q: %v", container, err)), nil
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	// Cap the read to maxLogBytes to prevent unbounded memory allocation.
 	logBytes, err := io.ReadAll(io.LimitReader(stream, maxLogBytes))

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -38,7 +38,7 @@ func (f *fakePodLogReader) GetLogs(_ context.Context, _, _ string, opts *corev1.
 func TestHandleGetInstance_AgentStatusEnrichment(t *testing.T) {
 	scheme := testScheme(t)
 	instance := runningInstance("my-agent", "user@example.com", "http://my-agent.klaus:8080")
-	instance.Spec.Claude.Model = "claude-sonnet-4-20250514"
+	instance.Spec.Claude.Model = "claude-sonnet-4-20250514" //nolint:goconst
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).Build()
 
@@ -256,7 +256,7 @@ func TestHandleGetInstance_ToolchainIncluded(t *testing.T) {
 		t.Fatalf("failed to parse response: %v", err)
 	}
 
-	if data["toolchain"] != "gsoci.azurecr.io/giantswarm/klaus-go:1.25" {
+	if data["toolchain"] != "gsoci.azurecr.io/giantswarm/klaus-go:1.25" { //nolint:goconst
 		t.Errorf("toolchain = %v, want %q", data["toolchain"], "gsoci.azurecr.io/giantswarm/klaus-go:1.25")
 	}
 }

--- a/internal/resources/builder.go
+++ b/internal/resources/builder.go
@@ -57,7 +57,7 @@ const (
 	GitSecretVolumeName = "git-secret"
 
 	// GitSecretMountPath is where the git secret is mounted in the init container.
-	GitSecretMountPath = "/etc/git-secret"
+	GitSecretMountPath = "/etc/git-secret" // #nosec G101 -- mount path, not a credential
 
 	// GitTmpVolumeName is the name of the emptyDir volume providing a writable
 	// /tmp for the git-clone init container. Required because the init container
@@ -175,7 +175,7 @@ func PluginMountPath(plugin klausv1alpha1.PluginReference) string {
 func ConfigMapChecksum(data map[string]string) string {
 	h := sha256.New()
 	for _, k := range slices.Sorted(maps.Keys(data)) {
-		fmt.Fprintf(h, "%s=%s\n", k, data[k])
+		_, _ = fmt.Fprintf(h, "%s=%s\n", k, data[k])
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -120,36 +120,36 @@ func renderSkillMD(skill klausv1alpha1.SkillConfig) string {
 	b.WriteString("---\n")
 
 	if skill.Description != "" {
-		b.WriteString(fmt.Sprintf("description: %q\n", skill.Description))
+		fmt.Fprintf(&b, "description: %q\n", skill.Description)
 	}
 	if skill.DisableModelInvocation != nil {
-		b.WriteString(fmt.Sprintf("disableModelInvocation: %t\n", *skill.DisableModelInvocation))
+		fmt.Fprintf(&b, "disableModelInvocation: %t\n", *skill.DisableModelInvocation)
 	}
 	if skill.UserInvocable != nil {
-		b.WriteString(fmt.Sprintf("userInvocable: %t\n", *skill.UserInvocable))
+		fmt.Fprintf(&b, "userInvocable: %t\n", *skill.UserInvocable)
 	}
 	if len(skill.AllowedTools) > 0 {
-		b.WriteString(fmt.Sprintf("allowedTools: %q\n", strings.Join(skill.AllowedTools, ",")))
+		fmt.Fprintf(&b, "allowedTools: %q\n", strings.Join(skill.AllowedTools, ","))
 	}
 	if skill.Model != "" {
-		b.WriteString(fmt.Sprintf("model: %q\n", skill.Model))
+		fmt.Fprintf(&b, "model: %q\n", skill.Model)
 	}
 	if skill.Context != nil && skill.Context.Raw != nil {
 		// Compact the JSON to a single line to avoid breaking YAML frontmatter
 		// structure with multi-line or YAML-special content.
 		compacted, err := compactJSON(skill.Context.Raw)
 		if err == nil {
-			b.WriteString(fmt.Sprintf("context:\n  %s\n", compacted))
+			fmt.Fprintf(&b, "context:\n  %s\n", compacted)
 		} else {
 			// Fall back to raw content if compaction fails.
-			b.WriteString(fmt.Sprintf("context:\n  %s\n", string(skill.Context.Raw)))
+			fmt.Fprintf(&b, "context:\n  %s\n", string(skill.Context.Raw))
 		}
 	}
 	if skill.Agent != "" {
-		b.WriteString(fmt.Sprintf("agent: %q\n", skill.Agent))
+		fmt.Fprintf(&b, "agent: %q\n", skill.Agent)
 	}
 	if skill.ArgumentHint != "" {
-		b.WriteString(fmt.Sprintf("argumentHint: %q\n", skill.ArgumentHint))
+		fmt.Fprintf(&b, "argumentHint: %q\n", skill.ArgumentHint)
 	}
 
 	b.WriteString("---\n")

--- a/internal/resources/configmap_test.go
+++ b/internal/resources/configmap_test.go
@@ -19,7 +19,7 @@ func TestBuildConfigMap_SystemPrompt(t *testing.T) {
 			},
 		},
 	}
-	instance.Name = "test-instance"
+	instance.Name = "test-instance" //nolint:goconst
 
 	cm, err := BuildConfigMap(instance, "test-ns")
 	if err != nil {

--- a/internal/resources/deployment_test.go
+++ b/internal/resources/deployment_test.go
@@ -25,7 +25,7 @@ func TestBuildDeployment_Basic(t *testing.T) {
 	configData := map[string]string{"system-prompt": "test prompt"}
 	dep := BuildDeployment(instance, "klaus-user-test", "gsoci.azurecr.io/giantswarm/klaus:v1.0.0", DefaultGitCloneImage, configData)
 
-	if dep.Name != "test-instance" {
+	if dep.Name != "test-instance" { //nolint:goconst
 		t.Errorf("Name = %q, want %q", dep.Name, "test-instance")
 	}
 	if dep.Namespace != "klaus-user-test" {

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	if err := (&controller.KlausInstanceReconciler{
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
-		Recorder:           mgr.GetEventRecorderFor("klausinstance-controller"),
+		Recorder:           mgr.GetEventRecorderFor("klausinstance-controller"), //nolint:staticcheck
 		KlausImage:         klausImage,
 		GitCloneImage:      gitCloneImage,
 		AnthropicKeySecret: anthropicKeySecret,
@@ -116,7 +116,7 @@ func main() {
 	if err := (&controller.KlausMCPServerReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorderFor("klausmcpserver-controller"),
+		Recorder:          mgr.GetEventRecorderFor("klausmcpserver-controller"), //nolint:staticcheck
 		OperatorNamespace: operatorNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KlausMCPServer")


### PR DESCRIPTION
## Summary

PR #89 (teams-alignment) updates the pre-commit workflow to install Go tooling (`go`, `golangci-lint`, `goimports`). With those tools in place, the pre-commit job now actually runs `golangci-lint` and surfaces pre-existing lint violations that had been silently skipped. Those same violations block #87, #89, and #90 from merging.

This PR applies the smallest viable source-level fixes so pre-commit CI can pass once the workflow update lands on main:

- `SA1019`: `mgr.GetEventRecorderFor` — add `//nolint:staticcheck` (upstream controller-runtime uses the same suppression; full migration to `GetEventRecorder` is an API change, out of scope)
- `ST1005`: lowercase the error string in `klausinstance_controller.go:294`
- `QF1012`: replace `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf` in `configmap.go`
- `errcheck`: ignore close/write errors in `tools.go` and `builder.go`
- `gosec G101`: annotate `GitSecretMountPath` (mount path, not a credential)
- `goconst`: suppress in test files (repeated string literals are intentional)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run -E=gosec -E=goconst -E=govet` reports 0 issues