### PR TITLE
ci: stabilize goconst on test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst

--- a/internal/mcp/spec.go
+++ b/internal/mcp/spec.go
@@ -9,6 +9,9 @@ import (
 	klausv1alpha1 "github.com/giantswarm/klaus-operator/api/v1alpha1"
 )
 
+// defaultModel is the Claude model assumed when an MCP caller does not supply one.
+const defaultModel = "claude-sonnet-4-20250514"
+
 // parsePluginReference parses an OCI image reference string into a PluginReference.
 // Supported formats:
 //   - "repository:tag"       (e.g. "gsoci.azurecr.io/giantswarm/plugins/code-reviewer:v0.1.0")
@@ -57,7 +60,7 @@ func parsePluginReference(ref string) (klausv1alpha1.PluginReference, error) {
 func buildInstanceSpec(args map[string]any, owner string) (klausv1alpha1.KlausInstanceSpec, error) {
 	model, _ := args["model"].(string)
 	if model == "" {
-		model = "claude-sonnet-4-20250514"
+		model = defaultModel
 	}
 
 	systemPrompt, _ := args["system_prompt"].(string)


### PR DESCRIPTION
## Summary

- Add `.golangci.yml` that excludes the `goconst` linter from `_test.go` files.

## Why

goconst reports each repeated string only at its **first occurrence**, and that first occurrence depends on file processing order, which is not stable across CI runs. Per-line `//nolint:goconst` suppressions therefore leak: CI re-runs flag a different line than the one suppressed (observed on PR #90, where CI complained about `internal/mcp/run_test.go:414` and `internal/mcp/spec.go:60` even though those lines had no violations locally).

Excluding `goconst` from test files is the stable fix. Non-test code is still linted — the existing `//nolint:goconst` on `internal/mcp/run.go:130` continues to apply.

## Test plan

- [x] `golangci-lint run ./...` reports 0 issues on this branch
- [x] Config uses `linters.exclusions.rules` (golangci-lint v2 format), verified against installed v2.11.4