### PR TITLE
ci: fix goconst lint violations

### DIFF
--- a/internal/mcp/agent.go
+++ b/internal/mcp/agent.go
@@ -37,7 +37,7 @@ func (s *Server) handlePromptInstance(ctx context.Context, request mcpgolang.Cal
 
 	args := request.GetArguments()
 
-	message, _ := args["message"].(string)
+	message, _ := args[keyMessage].(string)
 	if message == "" {
 		return mcpError("message is required"), nil
 	}
@@ -67,7 +67,7 @@ func (s *Server) handlePromptInstance(ctx context.Context, request mcpgolang.Cal
 	if !blocking {
 		return mcpSuccess(promptResult{
 			Instance:  instance.Name,
-			Status:    "started",
+			Status:    statusStarted,
 			SessionID: s.agentClient.SessionID(instance.Name),
 			Result:    extractText(toolResult),
 		}), nil
@@ -83,7 +83,7 @@ func (s *Server) handlePromptInstance(ctx context.Context, request mcpgolang.Cal
 
 	return mcpSuccess(promptResult{
 		Instance:  instance.Name,
-		Status:    "completed",
+		Status:    statusCompleted,
 		SessionID: s.agentClient.SessionID(instance.Name),
 		Result:    result,
 	}), nil
@@ -135,7 +135,7 @@ func (s *Server) handleGetResult(ctx context.Context, request mcpgolang.CallTool
 	if toolResult.IsError {
 		return mcpSuccess(agentResult{
 			Instance: instance.Name,
-			Status:   "error",
+			Status:   statusError,
 			Result:   extractText(toolResult),
 		}), nil
 	}
@@ -166,7 +166,7 @@ func (s *Server) handleGetResult(ctx context.Context, request mcpgolang.CallTool
 	// Fallback: response is not the expected JSON structure.
 	return mcpSuccess(agentResult{
 		Instance: instance.Name,
-		Status:   "completed",
+		Status:   statusCompleted,
 		Result:   text,
 	}), nil
 }
@@ -185,9 +185,9 @@ func (s *Server) agentBaseURL(instance *klausv1alpha1.KlausInstance) (string, *m
 
 // terminalStatuses are the agent statuses that indicate the task is done.
 var terminalStatuses = map[string]bool{
-	"completed": true,
-	"error":     true,
-	"failed":    true,
+	statusCompleted: true,
+	statusError:     true,
+	"failed":        true,
 }
 
 // waitForResult polls the agent's status tool until the task completes or the

--- a/internal/mcp/agentclient.go
+++ b/internal/mcp/agentclient.go
@@ -104,7 +104,7 @@ func (c *agentMCPClient) callTool(ctx context.Context, instanceName, baseURL, to
 
 func (c *agentMCPClient) Prompt(ctx context.Context, instanceName, baseURL, message string) (*mcpgolang.CallToolResult, error) {
 	return c.callTool(ctx, instanceName, baseURL, "prompt", map[string]any{
-		"message": message,
+		keyMessage: message,
 	})
 }
 

--- a/internal/mcp/constants.go
+++ b/internal/mcp/constants.go
@@ -1,0 +1,24 @@
+package mcp
+
+// Shared string constants used across MCP tool handlers. Extracted from
+// repeated literals to satisfy goconst and to centralise the JSON keys and
+// status values that form the MCP tool response contract.
+const (
+	// JSON keys returned in tool response payloads.
+	keyName        = "name"
+	keyStatus      = "status"
+	keyMessage     = "message"
+	keyOwner       = "owner"
+	keyModel       = "model"
+	keyMode        = "mode"
+	keyPersonality = "personality"
+	keyPlugins     = "plugins"
+
+	// Status values returned in tool response payloads.
+	statusStarted   = "started"
+	statusCompleted = "completed"
+	statusError     = "error"
+
+	// klausContainerName is the canonical container name in instance pods.
+	klausContainerName = "klaus"
+)

--- a/internal/mcp/lifecycle.go
+++ b/internal/mcp/lifecycle.go
@@ -19,9 +19,9 @@ func (s *Server) handleStopInstance(ctx context.Context, request mcpgolang.CallT
 	// Already stopped -- return a clear message, not an error.
 	if instance.Spec.Stopped {
 		return mcpSuccess(map[string]any{
-			"name":    instance.Name,
-			"status":  "already_stopped",
-			"message": fmt.Sprintf("Instance '%s' is already stopped", instance.Name),
+			keyName:    instance.Name,
+			keyStatus:  "already_stopped",
+			keyMessage: fmt.Sprintf("Instance '%s' is already stopped", instance.Name),
 		}), nil
 	}
 
@@ -33,9 +33,9 @@ func (s *Server) handleStopInstance(ctx context.Context, request mcpgolang.CallT
 	}
 
 	return mcpSuccess(map[string]any{
-		"name":    instance.Name,
-		"status":  "stopping",
-		"message": fmt.Sprintf("Instance '%s' is being stopped", instance.Name),
+		keyName:    instance.Name,
+		keyStatus:  "stopping",
+		keyMessage: fmt.Sprintf("Instance '%s' is being stopped", instance.Name),
 	}), nil
 }
 
@@ -50,9 +50,9 @@ func (s *Server) handleStartInstance(ctx context.Context, request mcpgolang.Call
 	// Not stopped -- return a clear message, not an error.
 	if !instance.Spec.Stopped {
 		return mcpSuccess(map[string]any{
-			"name":    instance.Name,
-			"status":  "already_running",
-			"message": fmt.Sprintf("Instance '%s' is not stopped (state: %s)", instance.Name, instance.Status.State),
+			keyName:    instance.Name,
+			keyStatus:  "already_running",
+			keyMessage: fmt.Sprintf("Instance '%s' is not stopped (state: %s)", instance.Name, instance.Status.State),
 		}), nil
 	}
 
@@ -64,8 +64,8 @@ func (s *Server) handleStartInstance(ctx context.Context, request mcpgolang.Call
 	}
 
 	return mcpSuccess(map[string]any{
-		"name":    instance.Name,
-		"status":  "starting",
-		"message": fmt.Sprintf("Instance '%s' is being started", instance.Name),
+		keyName:    instance.Name,
+		keyStatus:  "starting",
+		keyMessage: fmt.Sprintf("Instance '%s' is being started", instance.Name),
 	}), nil
 }

--- a/internal/mcp/run.go
+++ b/internal/mcp/run.go
@@ -44,12 +44,12 @@ func (s *Server) handleRunInstance(ctx context.Context, request mcpgolang.CallTo
 
 	args := request.GetArguments()
 
-	name, _ := args["name"].(string)
+	name, _ := args[keyName].(string)
 	if name == "" {
 		return mcpError("name is required"), nil
 	}
 
-	message, _ := args["message"].(string)
+	message, _ := args[keyMessage].(string)
 	if message == "" {
 		return mcpError("message is required"), nil
 	}
@@ -110,7 +110,7 @@ func (s *Server) handleRunInstance(ctx context.Context, request mcpgolang.CallTo
 		Owner:     user,
 		Model:     spec.Claude.Model,
 		Namespace: resources.UserNamespace(user),
-		Status:    "started",
+		Status:    statusStarted,
 		SessionID: s.agentClient.SessionID(name),
 		Result:    extractText(toolResult),
 	}
@@ -127,7 +127,7 @@ func (s *Server) handleRunInstance(ctx context.Context, request mcpgolang.CallTo
 		return mcpError(fmt.Sprintf("prompt sent but waiting for result failed: %v", err)), nil
 	}
 
-	res.Status = "completed" //nolint:goconst
+	res.Status = statusCompleted
 	res.Result = result
 	return mcpSuccess(res), nil
 }

--- a/internal/mcp/spec.go
+++ b/internal/mcp/spec.go
@@ -58,13 +58,13 @@ func parsePluginReference(ref string) (klausv1alpha1.PluginReference, error) {
 // and Workspace fields populated based on the provided arguments. Fields not
 // present in args are left at their zero values.
 func buildInstanceSpec(args map[string]any, owner string) (klausv1alpha1.KlausInstanceSpec, error) {
-	model, _ := args["model"].(string)
+	model, _ := args[keyModel].(string)
 	if model == "" {
 		model = defaultModel
 	}
 
 	systemPrompt, _ := args["system_prompt"].(string)
-	personality, _ := args["personality"].(string)
+	personality, _ := args[keyPersonality].(string)
 
 	spec := klausv1alpha1.KlausInstanceSpec{
 		Owner: owner,
@@ -128,7 +128,7 @@ func buildInstanceSpec(args map[string]any, owner string) (klausv1alpha1.KlausIn
 	}
 
 	// Mode.
-	if v, _ := args["mode"].(string); v != "" {
+	if v, _ := args[keyMode].(string); v != "" {
 		switch v {
 		case klausv1alpha1.ModeAgent, klausv1alpha1.ModeChat:
 			spec.Claude.Mode = &v
@@ -148,7 +148,7 @@ func buildInstanceSpec(args map[string]any, owner string) (klausv1alpha1.KlausIn
 	}
 
 	// Plugins.
-	if pluginRefs := parseStringArray(args["plugins"]); len(pluginRefs) > 0 {
+	if pluginRefs := parseStringArray(args[keyPlugins]); len(pluginRefs) > 0 {
 		plugins := make([]klausv1alpha1.PluginReference, 0, len(pluginRefs))
 		for _, ref := range pluginRefs {
 			p, err := parsePluginReference(ref)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -30,7 +30,7 @@ func (s *Server) handleCreateInstance(ctx context.Context, request mcpgolang.Cal
 
 	args := request.GetArguments()
 
-	name, _ := args["name"].(string)
+	name, _ := args[keyName].(string)
 	if name == "" {
 		return mcpError("name is required"), nil
 	}
@@ -56,11 +56,11 @@ func (s *Server) handleCreateInstance(ctx context.Context, request mcpgolang.Cal
 	}
 
 	return mcpSuccess(map[string]any{
-		"name":      name,
-		"owner":     user,
-		"model":     spec.Claude.Model,
+		keyName:     name,
+		keyOwner:    user,
+		keyModel:    spec.Claude.Model,
 		"namespace": resources.UserNamespace(user),
-		"status":    "creating",
+		keyStatus:   "creating",
 	}), nil
 }
 
@@ -82,19 +82,19 @@ func (s *Server) handleListInstances(ctx context.Context, _ mcpgolang.CallToolRe
 			continue
 		}
 		userInstances = append(userInstances, map[string]any{
-			"name":        inst.Name,
-			"state":       string(inst.Status.State),
-			"endpoint":    inst.Status.Endpoint,
-			"mode":        inst.Status.Mode,
-			"personality": inst.Status.Personality,
-			"plugins":     inst.Status.PluginCount,
-			"mcpServers":  inst.Status.MCPServerCount,
-			"age":         time.Since(inst.CreationTimestamp.Time).Truncate(time.Second).String(),
+			keyName:        inst.Name,
+			"state":        string(inst.Status.State),
+			"endpoint":     inst.Status.Endpoint,
+			keyMode:        inst.Status.Mode,
+			keyPersonality: inst.Status.Personality,
+			keyPlugins:     inst.Status.PluginCount,
+			"mcpServers":   inst.Status.MCPServerCount,
+			"age":          time.Since(inst.CreationTimestamp.Time).Truncate(time.Second).String(),
 		})
 	}
 
 	return mcpSuccess(map[string]any{
-		"owner":     user,
+		keyOwner:    user,
 		"count":     len(userInstances),
 		"instances": userInstances,
 	}), nil
@@ -112,9 +112,9 @@ func (s *Server) handleDeleteInstance(ctx context.Context, request mcpgolang.Cal
 	}
 
 	return mcpSuccess(map[string]any{
-		"name":    instance.Name,
-		"status":  "deleting",
-		"message": "Instance '" + instance.Name + "' is being deleted",
+		keyName:    instance.Name,
+		keyStatus:  "deleting",
+		keyMessage: "Instance '" + instance.Name + "' is being deleted",
 	}), nil
 }
 
@@ -132,17 +132,17 @@ func (s *Server) handleGetInstance(ctx context.Context, request mcpgolang.CallTo
 	}
 
 	result := map[string]any{
-		"name":        instance.Name,
-		"owner":       instance.Spec.Owner,
-		"state":       string(instance.Status.State),
-		"endpoint":    instance.Status.Endpoint,
-		"mode":        instance.Status.Mode,
-		"model":       instance.Spec.Claude.Model,
-		"personality": instance.Status.Personality,
-		"plugins":     instance.Status.PluginCount,
-		"mcpServers":  instance.Status.MCPServerCount,
-		"created":     instance.CreationTimestamp.Format(time.RFC3339),
-		"namespace":   resources.UserNamespace(instance.Spec.Owner),
+		keyName:        instance.Name,
+		keyOwner:       instance.Spec.Owner,
+		"state":        string(instance.Status.State),
+		"endpoint":     instance.Status.Endpoint,
+		keyMode:        instance.Status.Mode,
+		keyModel:       instance.Spec.Claude.Model,
+		keyPersonality: instance.Status.Personality,
+		keyPlugins:     instance.Status.PluginCount,
+		"mcpServers":   instance.Status.MCPServerCount,
+		"created":      instance.CreationTimestamp.Format(time.RFC3339),
+		"namespace":    resources.UserNamespace(instance.Spec.Owner),
 	}
 
 	if instance.Status.Toolchain != "" {
@@ -236,9 +236,9 @@ func (s *Server) handleRestartInstance(ctx context.Context, request mcpgolang.Ca
 	}
 
 	return mcpSuccess(map[string]any{
-		"name":    instance.Name,
-		"status":  "restarting",
-		"message": "Instance '" + instance.Name + "' is being restarted",
+		keyName:    instance.Name,
+		keyStatus:  "restarting",
+		keyMessage: "Instance '" + instance.Name + "' is being restarted",
 	}), nil
 }
 
@@ -270,7 +270,7 @@ func (s *Server) handleGetLogs(ctx context.Context, request mcpgolang.CallToolRe
 	}
 
 	// Parse optional container parameter (default "klaus").
-	container := "klaus"
+	container := klausContainerName
 	if v, _ := args["container"].(string); v != "" {
 		container = v
 	}
@@ -335,7 +335,7 @@ func (s *Server) getOwnedInstance(ctx context.Context, request mcpgolang.CallToo
 	}
 
 	args := request.GetArguments()
-	name, _ := args["name"].(string)
+	name, _ := args[keyName].(string)
 	if name == "" {
 		return nil, mcpError("name is required")
 	}
@@ -414,7 +414,7 @@ func (s *Server) listEntries(ctx context.Context, listFn func(context.Context, .
 	items := make([]map[string]any, 0, len(entries))
 	for _, e := range entries {
 		item := map[string]any{
-			"name":       e.Name,
+			keyName:      e.Name,
 			"repository": e.Repository,
 			"reference":  e.Reference,
 		}

--- a/internal/resources/builder.go
+++ b/internal/resources/builder.go
@@ -75,6 +75,30 @@ const (
 	// Pinned to a specific version for reproducible deployments; override via
 	// the --git-clone-image flag.
 	DefaultGitCloneImage = "alpine/git:v2.47.2"
+
+	// LabelAppName is the standard Kubernetes "app.kubernetes.io/name" label key.
+	LabelAppName = "app.kubernetes.io/name"
+
+	// LabelManagedBy is the standard Kubernetes "app.kubernetes.io/managed-by" label key.
+	LabelManagedBy = "app.kubernetes.io/managed-by"
+
+	// LabelOwner is the per-owner label key applied to instance-scoped resources.
+	LabelOwner = "klaus.giantswarm.io/owner"
+
+	// AppKlaus is the value of LabelAppName for instance-scoped resources.
+	AppKlaus = "klaus"
+
+	// AppKlausOperator is the value of LabelManagedBy for resources reconciled
+	// by this operator. It is also the LabelAppName value used for the
+	// operator's own MCP server registration.
+	AppKlausOperator = "klaus-operator"
+
+	// HTTPPortName is the named port shared by the Deployment and Service.
+	HTTPPortName = "http"
+
+	// envValueTrue is the string "true" used as a value for boolean-style
+	// environment variables passed to the Klaus container.
+	envValueTrue = "true"
 )
 
 var sanitizeRegexp = regexp.MustCompile(`[^a-z0-9-]`)
@@ -90,7 +114,7 @@ func UserNamespace(owner string) string {
 // diverge, the Service silently stops matching pods.
 func SelectorLabels(instance *klausv1alpha1.KlausInstance) map[string]string {
 	return map[string]string{
-		"app.kubernetes.io/name":     "klaus",
+		LabelAppName:                 AppKlaus,
 		"app.kubernetes.io/instance": instance.Name,
 	}
 }
@@ -98,8 +122,8 @@ func SelectorLabels(instance *klausv1alpha1.KlausInstance) map[string]string {
 // InstanceLabels returns standard labels for resources owned by the instance.
 func InstanceLabels(instance *klausv1alpha1.KlausInstance) map[string]string {
 	labels := SelectorLabels(instance)
-	labels["app.kubernetes.io/managed-by"] = "klaus-operator"
-	labels["klaus.giantswarm.io/owner"] = sanitizeLabelValue(instance.Spec.Owner)
+	labels[LabelManagedBy] = AppKlausOperator
+	labels[LabelOwner] = sanitizeLabelValue(instance.Spec.Owner)
 	return labels
 }
 
@@ -108,10 +132,10 @@ func InstanceLabels(instance *klausv1alpha1.KlausInstance) map[string]string {
 // use managed-by and owner labels without instance-specific identifiers.
 func MCPSecretLabels(owner string) map[string]string {
 	return map[string]string{
-		"app.kubernetes.io/name":       "klaus",
-		"app.kubernetes.io/managed-by": "klaus-operator",
-		"app.kubernetes.io/component":  "mcp-secret",
-		"klaus.giantswarm.io/owner":    sanitizeLabelValue(owner),
+		LabelAppName:                  AppKlaus,
+		LabelManagedBy:                AppKlausOperator,
+		"app.kubernetes.io/component": "mcp-secret",
+		LabelOwner:                    sanitizeLabelValue(owner),
 	}
 }
 

--- a/internal/resources/deployment.go
+++ b/internal/resources/deployment.go
@@ -74,11 +74,11 @@ func BuildDeployment(instance *klausv1alpha1.KlausInstance, namespace, klausImag
 					},
 					Containers: []corev1.Container{
 						{
-							Name:  "klaus",
+							Name:  AppKlaus,
 							Image: klausImage,
 							Ports: []corev1.ContainerPort{
 								{
-									Name:          "http",
+									Name:          HTTPPortName,
 									ContainerPort: int32(KlausPort),
 									Protocol:      corev1.ProtocolTCP,
 								},

--- a/internal/resources/env.go
+++ b/internal/resources/env.go
@@ -81,7 +81,7 @@ func BuildEnvVars(instance *klausv1alpha1.KlausInstance, configMapName, secretNa
 	if instance.Spec.Claude.StrictMCPConfig == nil || *instance.Spec.Claude.StrictMCPConfig {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "CLAUDE_STRICT_MCP_CONFIG",
-			Value: "true",
+			Value: envValueTrue,
 		})
 	}
 
@@ -212,7 +212,7 @@ func BuildEnvVars(instance *klausv1alpha1.KlausInstance, configMapName, secretNa
 	if hasAddDirs && loadMemory {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD",
-			Value: "true",
+			Value: envValueTrue,
 		})
 	}
 
@@ -243,7 +243,7 @@ func BuildEnvVars(instance *klausv1alpha1.KlausInstance, configMapName, secretNa
 	if instance.Spec.Claude.IncludePartialMessages != nil && *instance.Spec.Claude.IncludePartialMessages {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "CLAUDE_INCLUDE_PARTIAL_MESSAGES",
-			Value: "true",
+			Value: envValueTrue,
 		})
 	}
 
@@ -365,13 +365,13 @@ func buildTelemetryEnvVars(instance *klausv1alpha1.KlausInstance) []corev1.EnvVa
 	if tel.LogUserPrompts != nil && *tel.LogUserPrompts {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "CLAUDE_CODE_LOG_USER_PROMPTS",
-			Value: "true",
+			Value: envValueTrue,
 		})
 	}
 	if tel.LogToolDetails != nil && *tel.LogToolDetails {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "CLAUDE_CODE_LOG_TOOL_DETAILS",
-			Value: "true",
+			Value: envValueTrue,
 		})
 	}
 
@@ -385,7 +385,7 @@ func buildTelemetryEnvVars(instance *klausv1alpha1.KlausInstance) []corev1.EnvVa
 	if tel.IncludeVersion != nil && *tel.IncludeVersion {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "CLAUDE_CODE_INCLUDE_VERSION",
-			Value: "true",
+			Value: envValueTrue,
 		})
 	}
 	if tel.IncludeAccountUUID != nil && !*tel.IncludeAccountUUID {

--- a/internal/resources/mcpserver.go
+++ b/internal/resources/mcpserver.go
@@ -37,9 +37,9 @@ func BuildMCPServerCRD(instance *klausv1alpha1.KlausInstance, instanceNamespace 
 				"name":      "klaus-" + instance.Name,
 				"namespace": musterNamespace,
 				"labels": map[string]any{
-					"app.kubernetes.io/managed-by": "klaus-operator",
-					"app.kubernetes.io/instance":   instance.Name,
-					"klaus.giantswarm.io/owner":    sanitizeLabelValue(instance.Spec.Owner),
+					LabelManagedBy:               AppKlausOperator,
+					"app.kubernetes.io/instance": instance.Name,
+					LabelOwner:                   sanitizeLabelValue(instance.Spec.Owner),
 				},
 			},
 			"spec": spec,
@@ -56,11 +56,11 @@ func BuildOperatorMCPServerCRD(operatorServiceURL, musterNamespace string) *unst
 			"apiVersion": "muster.giantswarm.io/v1alpha1",
 			"kind":       "MCPServer",
 			"metadata": map[string]any{
-				"name":      "klaus-operator",
+				"name":      AppKlausOperator,
 				"namespace": musterNamespace,
 				"labels": map[string]any{
-					"app.kubernetes.io/managed-by": "klaus-operator",
-					"app.kubernetes.io/name":       "klaus-operator",
+					LabelManagedBy: AppKlausOperator,
+					LabelAppName:   AppKlausOperator,
 				},
 			},
 			"spec": map[string]any{

--- a/internal/resources/namespace.go
+++ b/internal/resources/namespace.go
@@ -13,8 +13,8 @@ func BuildNamespace(instance *klausv1alpha1.KlausInstance) *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: UserNamespace(instance.Spec.Owner),
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "klaus-operator",
-				"klaus.giantswarm.io/owner":    sanitizeLabelValue(instance.Spec.Owner),
+				LabelManagedBy: AppKlausOperator,
+				LabelOwner:     sanitizeLabelValue(instance.Spec.Owner),
 			},
 		},
 	}

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -25,9 +25,9 @@ func BuildService(instance *klausv1alpha1.KlausInstance, namespace string) *core
 			Selector: SelectorLabels(instance),
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "http",
+					Name:       HTTPPortName,
 					Port:       int32(KlausPort),
-					TargetPort: intstr.FromString("http"),
+					TargetPort: intstr.FromString(HTTPPortName),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},


### PR DESCRIPTION
## Summary

- golangci-lint 2.12.2 (which embeds goconst v1.10.0) on `main` has been flagging 30 pre-existing repeated-string violations across `internal/mcp` and `internal/resources`. The `pre-commit` job is non-required today but is about to become required, so this PR resolves the findings now.
- Pure constants-extraction refactor — every new constant binds to the exact string it replaces, so there is no behavioural change.

## Changes

- `internal/mcp/constants.go` (new): JSON response keys (`keyName`, `keyStatus`, `keyMessage`, `keyOwner`, `keyModel`, `keyMode`, `keyPersonality`, `keyPlugins`), status values (`statusStarted`, `statusCompleted`, `statusError`), and `klausContainerName` for the default agent container name.
- `internal/resources/builder.go`: adds exported `LabelAppName`, `LabelManagedBy`, `LabelOwner`, `AppKlaus`, `AppKlausOperator`, `HTTPPortName`, and unexported `envValueTrue`. Used by `deployment.go`, `service.go`, `mcpserver.go`, `namespace.go`, `env.go` and `builder.go` itself.

Out of scope: `internal/controller/klausinstance_controller.go` has 2 occurrences of the `managed-by`/`klaus-operator` literal — below the goconst threshold of 3 so it is not flagged. Left for a follow-up.

## Test plan

- [x] `golangci-lint run -E=gosec -E=goconst -E=govet ./...` — `0 issues.`
- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `go mod tidy` — no changes
- [ ] CI `pre-commit` job green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)