### PR TITLE
ci: migrate to architect-orb 8.1.0 multi-arch path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@8.0.2
+  architect: giantswarm/architect@8.1.0
 
 workflows:
   test:
@@ -15,8 +15,9 @@ workflows:
               only: /^v.*/
 
       # Branch builds: amd64 only for faster PR feedback
-      - architect/push-to-registries-multiarch:
+      - architect/push-to-registries:
           context: architect
+          multiarch: true
           name: push-to-registries
           platforms: "linux/amd64"
           requires:
@@ -28,8 +29,9 @@ workflows:
                 - master
 
       # Tag builds: full multi-arch (amd64 + arm64)
-      - architect/push-to-registries-multiarch:
+      - architect/push-to-registries:
           context: architect
+          multiarch: true
           name: push-to-registries-release
           requires:
             - go-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `giantswarm/architect` orb to `8.1.0` and migrate image pushes from the deprecated `push-to-registries-multiarch` job to `push-to-registries` with `multiarch: true`. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels.
+
 ### Added
 
 - Auto-release workflow: automatically creates a patch version tag on every PR merge to `main`, triggering CircleCI to build and publish Docker images and Helm charts.


### PR DESCRIPTION
## Summary

- Bump `giantswarm/architect` orb to `8.1.0`.
- Migrate every image push from the deprecated `architect/push-to-registries-multiarch` job to `architect/push-to-registries` with `multiarch: true`.

## Why

The `push-to-registries-multiarch` job was deprecated in orb v7.0.0 and will be removed in the next major version. Bumping to v8.1.0 picks up automatic QEMU/binfmt registration, hardened buildx bootstrap, and standard OCI image labels emitted by default.

## Test plan

- [x] Branch CI exercises the new `push-to-registries` (`multiarch: true`, `platforms: linux/amd64`) on this PR.
- [ ] Auto-release tag after merge exercises the full multi-arch (amd64+arm64) tag-build path.

Made with [Cursor](https://cursor.com)