### PR TITLE
ci: enable split-china-push for the Aliyun mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,30 @@ workflows:
                 - main
                 - master
 
-      # Tag builds: full multi-arch (amd64 + arm64)
+      # Tag builds: full multi-arch (amd64 + arm64). split-china-push skips
+      # the Aliyun mirror; the sync-china-registry job below mirrors the image
+      # from gsoci to Aliyun via the in-China galaxy-runner.
       - architect/push-to-registries:
           context: architect
           multiarch: true
           name: push-to-registries-release
+          split-china-push: true
           requires:
             - go-build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      # Mirror the image gsoci -> Aliyun via the in-China runner. Runs on the
+      # giantswarm/galaxy-runner resource class. Does NOT block the chart push.
+      - architect/sync-china-registry:
+          context: architect
+          name: sync-china-registry
+          requires:
+            - go-build
+            - push-to-registries-release
           filters:
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enable `split-china-push: true` on the tag-build `push-to-registries-release` job and add a companion `sync-china-registry` job. The cross-Pacific `docker buildx` push to the Aliyun mirror (which has been timing out for ~10 minutes and failing the whole job) is replaced with a `regctl image copy` from gsoci to Aliyun executed on the in-China `giantswarm/galaxy-runner` self-hosted CircleCI runner. The Aliyun sync no longer blocks the chart-catalog publish chain.
 - Bump `giantswarm/architect` orb to `8.1.0` and migrate image pushes from the deprecated `push-to-registries-multiarch` job to `push-to-registries` with `multiarch: true`. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels.
 
 ### Added


### PR DESCRIPTION
## Summary

- Add `split-china-push: true` to the tag-build `push-to-registries-release` job.
- Add a companion `architect/sync-china-registry` job that mirrors the image gsoci -> Aliyun on the in-China `giantswarm/galaxy-runner`.

## Why

After migrating to `architect@8.1.0` + `push-to-registries` (`multiarch: true`) in #116, the tag-build hit the long-standing Aliyun cross-Pacific `docker buildx` push timeout (~10 minutes) and failed `push-to-registries-release` even though the gsoci push had already succeeded with a real multi-arch (amd64+arm64) manifest. Tag `v0.0.70` is the most recent example.

`split-china-push: true` (orb v7.1.0+) is the official fix: the main `push-to-registries` job pushes to gsoci/gsociprivate only, caches the image registry+tag, and a separate `sync-china-registry` job running on the `giantswarm/galaxy-runner` self-hosted CircleCI runner inside China uses `regctl image copy` to mirror the image gsoci -> Aliyun (with Singapore replica acceleration + 10x retries for eventual-consistency races).

## Test plan

- [x] Branch CI exercises the unchanged `push-to-registries` (`multiarch: true`, `platforms: linux/amd64`) job on this PR.
- [ ] Next `v*` tag exercises the new `split-china-push` + `sync-china-registry` flow end-to-end.


Made with [Cursor](https://cursor.com)