### PR TITLE
ci: bump giantswarm/architect orb to 8.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@8.1.0
+  architect: giantswarm/architect@8.2.1
 
 workflows:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+- Bump `giantswarm/architect` orb to `8.2.1` to pick up [architect-orb#767](https://github.com/giantswarm/architect-orb/pull/767): `image-login-to-registries` is now POSIX-portable, unblocking `architect/sync-china-registry` (the gsoci -> Aliyun mirror via the in-China `giantswarm/galaxy-runner`). The v8.1.0 refactor accidentally introduced bash-only `${!var}` indirect expansion in the shared login command, which BusyBox `/bin/sh` (used by the regctl executor) rejected with `bad substitution` -- so no Aliyun mirror has been happening since the migration to `split-china-push: true`. v8.2.x also enables cosign keyless signing, SLSA provenance, and SBOM attestations by default for public images and charts.
 - Enable `split-china-push: true` on the tag-build `push-to-registries-release` job and add a companion `sync-china-registry` job. The cross-Pacific `docker buildx` push to the Aliyun mirror (which has been timing out for ~10 minutes and failing the whole job) is replaced with a `regctl image copy` from gsoci to Aliyun executed on the in-China `giantswarm/galaxy-runner` self-hosted CircleCI runner. The Aliyun sync no longer blocks the chart-catalog publish chain.
 - Bump `giantswarm/architect` orb to `8.1.0` and migrate image pushes from the deprecated `push-to-registries-multiarch` job to `push-to-registries` with `multiarch: true`. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels.
 


### PR DESCRIPTION
## Summary

Bump `giantswarm/architect` orb `8.1.0` -> `8.2.1`.

## Why

v8.2.1 ships [architect-orb#767](https://github.com/giantswarm/architect-orb/pull/767), which makes the shared `image-login-to-registries` command POSIX-portable. The v8.1.0 refactor (#736) had accidentally introduced bash-only `${!var}` indirect expansion and `[[ ... ]]` test brackets, which BusyBox `/bin/sh` (used by the `regctl` executor under `architect/sync-china-registry`) rejects with `/bin/sh: syntax error: bad substitution`.

Since this repo migrated to `split-china-push: true` + `sync-china-registry`, every tag pipeline's mirror step has been failing before any login was attempted -- so no image has actually been mirrored gsoci -> Aliyun since 2026-05-18. This bump unblocks the next tag pipeline's mirror step.

v8.2.x also enables, by default, cosign keyless signing, SLSA provenance, and SBOM attestations for public images and Helm charts (closes the supply-chain loop for public artifacts in this repo).

## Test plan

- [x] Branch CI exercises the bumped orb on this PR.
- [ ] Next `v*` tag exercises `sync-china-registry` end-to-end (the gsoci side already works under 8.1.0; the Aliyun mirror is the new behaviour being validated).