### PR TITLE
fix(build): use CI-built binary in container image instead of rebuilding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,14 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
-
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-ARG TARGETOS
-ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
-    -ldflags "-w -extldflags '-static'" \
-    -o klaus-operator .
-
+# The Go binary is built by CircleCI (architect/go-build) and attached to the
+# build context as <binary>-<os>-<arch>; this image only assembles the runtime.
+# For a local build, produce the binary first:
+#   CGO_ENABLED=0 go build -o klaus-operator-linux-amd64 .
 FROM gsoci.azurecr.io/giantswarm/alpine:3.24.0
 
 RUN apk add --no-cache ca-certificates
 
-COPY --from=builder /app/klaus-operator /klaus-operator
+ARG TARGETOS
+ARG TARGETARCH
+COPY klaus-operator-${TARGETOS}-${TARGETARCH} /klaus-operator
 
 USER 65532:65532
 


### PR DESCRIPTION
## Summary

- The Dockerfile rebuilt the Go binary in a `golang` builder stage even though CircleCI's `architect/go-build` job already builds and signs `klaus-operator-<os>-<arch>` binaries and attaches them to the workspace. The image now copies the prebuilt binary for the target platform — same pattern as muster. Image builds stop paying a full Go compile per platform, and the binary that ships is the one CI built and tested.

## Test plan

- [x] Local validation: built `klaus-operator-linux-amd64` with `CGO_ENABLED=0 go build` and confirmed `docker build .` succeeds and the binary runs in the image
- [ ] Branch CI green

Made with [Cursor](https://cursor.com)